### PR TITLE
feat: add minimal FastAPI server for Render deployment

### DIFF
--- a/knowledge_model/api/main.py
+++ b/knowledge_model/api/main.py
@@ -1,0 +1,17 @@
+"""
+main.py
+Minimal FastAPI app so our Render service has a running server.
+"""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def health_check():
+    return {"status": "ok", "message": "Knowledge Model API is alive!"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
- Creates knowledge_model/api/main.py with a simple health check
- Updates requirements to include fastapi and uvicorn
- Enables a long-running web service on Render